### PR TITLE
Draft: output product

### DIFF
--- a/DataFormats/L1TParticleFlow/interface/PFJet.h
+++ b/DataFormats/L1TParticleFlow/interface/PFJet.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 #include "DataFormats/L1TParticleFlow/interface/PFCandidate.h"
+#include "DataFormats/L1TParticleFlow/interface/jets.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
 namespace l1t {
@@ -12,6 +13,7 @@ namespace l1t {
   public:
     /// constituent information. note that this is not going to be available in the hardware!
     typedef std::vector<edm::Ptr<l1t::PFCandidate>> Constituents;
+
 
     PFJet() {}
     PFJet(float pt, float eta, float phi, float mass = 0, int hwpt = 0, int hweta = 0, int hwphi = 0)
@@ -30,6 +32,15 @@ namespace l1t {
     const Constituents& constituents() const { return constituents_; }
     /// adds a candidate to this cluster; note that this only records the information, it's up to you to also set the 4-vector appropriately
     void addConstituent(const edm::Ptr<l1t::PFCandidate>& cand) { constituents_.emplace_back(cand); }
+
+    // add jet tag prediction results
+    void addTagScores(std::vector<float> scores, std::vector<l1ct::JetTagClass> classes){
+      tagScores_ = scores;
+      tagClasses_ = classes;
+    }
+
+    std::vector<float> getTagScores() const { return tagScores_; }
+    std::vector<l1ct::JetTagClass> getTagClasses() const { return tagClasses_; }
 
     // candidate interface
     size_t numberOfDaughters() const override { return constituents_.size(); }
@@ -55,6 +66,8 @@ namespace l1t {
   private:
     float rawPt_;
     Constituents constituents_;
+    std::vector<l1ct::JetTagClass> tagClasses_;
+    std::vector<float> tagScores_;
     std::array<PackedJet, 2> encodedJet_ = {{{{0, 0}}, {{0, 0}}}};
   };
 

--- a/DataFormats/L1TParticleFlow/interface/datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/datatypes.h
@@ -35,6 +35,7 @@ namespace l1ct {
   typedef ap_uint<4> redChi2Bin_t;
   typedef ap_fixed<10, 1, AP_RND_CONV, AP_SAT> id_score_t;  // ID score to be between -1 (background) and 1 (signal)
   typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;   // result_t from the NN is still apx_fixed<16,6>
+  typedef ap_ufixed<8, 1, AP_RND_CONV, AP_SAT> jet_tag_score_t; // 8 bit jet jet probability from 0 to 1
 
   // FIXME: adjust range 10-11bits -> 1/4 - 1/2TeV is probably more than enough for all reasonable use cases
   typedef ap_ufixed<11, 9, AP_TRN, AP_SAT> iso_t;

--- a/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
+++ b/DataFormats/L1TParticleFlow/interface/gt_datatypes.h
@@ -26,7 +26,7 @@ namespace l1gt {
   typedef ap_fixed<14, 14, AP_RND_CONV, AP_SAT> eta_t;
   // While bitwise identical to the l1ct::z0_t value, we store z0 in mm to profit of ap_fixed goodies
   typedef ap_fixed<10, 9, AP_RND_CONV, AP_SAT> z0_t;  // NOTE: mm instead of cm!!!
-  typedef ap_ufixed<10, 1, AP_RND, AP_SAT> b_tag_score_t;
+  typedef ap_ufixed<8, 1, AP_RND, AP_SAT> id_proba_t; // for IDs bounded in range [0-1]
   typedef ap_uint<1> valid_t;
 
   // E/gamma fields
@@ -84,12 +84,20 @@ namespace l1gt {
   };
 
   struct Jet {
+    static const unsigned NTagFields = 8;
     valid_t valid;
     ThreeVector v3;
     z0_t z0;
-    b_tag_score_t hwBtagScore;
+    // class probabilities for tag categories
+    id_proba_t hwTagScores[NTagFields];
 
-    inline bool operator==(const Jet &other) const { return valid == other.valid && z0 == other.z0 && v3 == other.v3; }
+    inline bool operator==(const Jet &other) const { 
+      bool eq = valid == other.valid && z0 == other.z0 && v3 == other.v3;
+      for(unsigned i = 0; i < NTagFields; i++){
+        eq = eq && hwTagScores[i] == other.hwTagScores[i];
+      }
+      return eq;
+    }
 
     static const int BITWIDTH = 128;
     inline ap_uint<BITWIDTH> pack_ap() const {
@@ -98,7 +106,9 @@ namespace l1gt {
       pack_into_bits(ret, start, valid);
       pack_into_bits(ret, start, v3.pack());
       pack_into_bits(ret, start, z0);
-      pack_into_bits(ret, start, hwBtagScore);
+      for(unsigned i = 0; i < NTagFields; i++){
+        pack_into_bits(ret, start, hwTagScores[i]);
+      }
       return ret;
     }
 
@@ -123,7 +133,9 @@ namespace l1gt {
       unpack_from_bits(src, start, v3.phi);
       unpack_from_bits(src, start, v3.eta);
       unpack_from_bits(src, start, z0);
-      unpack_from_bits(src, start, hwBtagScore);
+      for(unsigned i = 0; i < NTagFields; i++){
+          unpack_from_bits(src, start, hwTagScores[i]);
+      }
     }
 
     inline static Jet unpack(const std::array<uint64_t, 2> &src) {

--- a/DataFormats/L1TParticleFlow/interface/jets.h
+++ b/DataFormats/L1TParticleFlow/interface/jets.h
@@ -6,18 +6,63 @@
 #include "DataFormats/L1TParticleFlow/interface/bit_encoding.h"
 #include <array>
 #include <cstdint>
+#include <vector>
+#include <unordered_map>
 
 namespace l1ct {
 
+  // all possible tag categories (can be extended for new / separate taggers)
+  class JetTagClass{
+  public:
+    enum JetTagClassValue {
+      uds, g, b, c, tau_p, tau_n, e, mu
+    };
+    JetTagClass() = default;
+    JetTagClass(JetTagClassValue aJetTagClassValue) : value_(aJetTagClassValue) { }
+    JetTagClass(std::string aJetTagClassValueString) {
+      auto it = labels_.find(aJetTagClassValueString);
+      if(it != labels_.end()){
+        value_ = it->second;
+      }else{
+        // TODO throw an error
+        value_ = JetTagClass::JetTagClassValue::uds;
+      }
+    }
+
+    inline bool operator==(const JetTagClass &other) const {
+      return value_ == other.value_; 
+    }
+
+  private:
+    JetTagClassValue value_;
+    static const std::unordered_map<std::string,JetTagClassValue> labels_;
+
+  }; // JetTagClass
+
   struct Jet {
+
     pt_t hwPt;
     glbeta_t hwEta;
     glbphi_t hwPhi;
     z0_t hwZ0;
-    b_tag_score_t hwBtagScore;
+
+    static const unsigned NTagFields = 8;
+    jet_tag_score_t hwTagScores[NTagFields];
+
+    static const std::vector<JetTagClass> tagClassesDefault_;
+    std::vector<JetTagClass> tagClasses;
+
+    Jet() : tagClasses(tagClassesDefault_){}
+    Jet(std::vector<JetTagClass> tagClasses){
+      this->tagClasses = tagClasses;
+    }
 
     inline bool operator==(const Jet &other) const {
-      return hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi;
+      bool eq = hwPt == other.hwPt && hwEta == other.hwEta && hwPhi == other.hwPhi && hwZ0 == other.hwZ0;
+      for(unsigned i = 0; i < NTagFields; i++){
+        eq = eq && hwTagScores[i] == other.hwTagScores[i];
+      }
+      return eq;
     }
 
     inline bool operator>(const Jet &other) const { return hwPt > other.hwPt; }
@@ -28,7 +73,9 @@ namespace l1ct {
       hwEta = 0;
       hwPhi = 0;
       hwZ0 = 0;
-      hwBtagScore = 0;
+      for(unsigned i = 0; i < NTagFields; i++){
+        hwTagScores[i] = 0;
+      }
     }
 
     int intPt() const { return Scales::intPt(hwPt); }
@@ -37,10 +84,23 @@ namespace l1ct {
     float floatPt() const { return Scales::floatPt(hwPt); }
     float floatEta() const { return Scales::floatEta(hwEta); }
     float floatPhi() const { return Scales::floatPhi(hwPhi); }
-    float floatBtagScore() const { return Scales::floatBtagScore(hwBtagScore); }
     float floatZ0() const { return Scales::floatZ0(hwZ0); }
+    float floatBTagScore() const {
+      float score = 0;
+      for(unsigned i = 0; i < tagClasses.size(); i++){
+        if(tagClasses[i] == JetTagClass("b")) score = (float) hwTagScores[i];          
+      }
+      return score;
+    }
+    std::vector<float> floatIDScores() const {
+      std::vector<float> scores;
+      for(unsigned i = 0; i < tagClasses.size(); i++){
+        scores.push_back( (float) hwTagScores[i] );
+      }    
+      return scores;
+    }
 
-    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + z0_t::width + b_tag_score_t::width;
+    static const int BITWIDTH = pt_t::width + glbeta_t::width + glbphi_t::width + z0_t::width + NTagFields * id_score_t::width;
     inline ap_uint<BITWIDTH> pack_ap() const {
       ap_uint<BITWIDTH> ret;
       unsigned int start = 0;
@@ -48,7 +108,9 @@ namespace l1ct {
       pack_into_bits(ret, start, hwEta);
       pack_into_bits(ret, start, hwPhi);
       pack_into_bits(ret, start, hwZ0);
-      pack_into_bits(ret, start, hwBtagScore);
+      for(unsigned i = 0; i < NTagFields; i++){
+        pack_into_bits(ret, start, hwTagScores[i]);
+      }
       return ret;
     }
 
@@ -72,7 +134,9 @@ namespace l1ct {
       unpack_from_bits(src, start, hwEta);
       unpack_from_bits(src, start, hwPhi);
       unpack_from_bits(src, start, hwZ0);
-      unpack_from_bits(src, start, hwBtagScore);
+      for(unsigned i = 0; i < NTagFields; i++){
+        unpack_from_bits(src, start, hwTagScores[i]);
+      }
     }
 
     inline static Jet unpack(const std::array<uint64_t, 2> &src) {
@@ -94,7 +158,9 @@ namespace l1ct {
       j.v3.phi = CTtoGT_phi(hwPhi);
       j.v3.eta = CTtoGT_eta(hwEta);
       j.z0(l1ct::z0_t::width - 1, 0) = hwZ0(l1ct::z0_t::width - 1, 0);
-      j.hwBtagScore = hwBtagScore;
+      for(unsigned i = 0; i < NTagFields; i++){
+        j.hwTagScores[i] = hwTagScores[i];
+      }
       return j;
     }
   };

--- a/DataFormats/L1TParticleFlow/src/jets.cpp
+++ b/DataFormats/L1TParticleFlow/src/jets.cpp
@@ -1,0 +1,21 @@
+#include "DataFormats/L1TParticleFlow/interface/jets.h"
+
+const std::unordered_map<std::string, l1ct::JetTagClass::JetTagClassValue> l1ct::JetTagClass::labels_ = {
+  {"uds"   , l1ct::JetTagClass::JetTagClassValue::uds},
+  {"g"     , l1ct::JetTagClass::JetTagClassValue::g},
+  {"b"     , l1ct::JetTagClass::JetTagClassValue::b},
+  {"c"     , l1ct::JetTagClass::JetTagClassValue::c},
+  {"tau_p" , l1ct::JetTagClass::JetTagClassValue::tau_p},
+  {"tau_n" , l1ct::JetTagClass::JetTagClassValue::tau_n},
+  {"e"     , l1ct::JetTagClass::JetTagClassValue::e},
+  {"mu"    , l1ct::JetTagClass::JetTagClassValue::mu}
+};
+
+const std::vector<l1ct::JetTagClass> l1ct::Jet::tagClassesDefault_ {l1ct::JetTagClass("uds"),
+                                                                    l1ct::JetTagClass("g"),
+                                                                    l1ct::JetTagClass("b"),
+                                                                    l1ct::JetTagClass("c"),
+                                                                    l1ct::JetTagClass("tau_p"),
+                                                                    l1ct::JetTagClass("tau_n"),
+                                                                    l1ct::JetTagClass("e"),
+                                                                    l1ct::JetTagClass("mu")};

--- a/L1Trigger/Phase2L1ParticleFlow/plugins/L1MultiJetProducer.cc
+++ b/L1Trigger/Phase2L1ParticleFlow/plugins/L1MultiJetProducer.cc
@@ -83,7 +83,6 @@ void L1MultiJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
     l1t::PFJet edmTaggedJet(srcjet.pt(), srcjet.eta(), srcjet.phi(), srcjet.mass(),
                             gtHWTaggedJet.v3.pt.V, gtHWTaggedJet.v3.eta.V, gtHWTaggedJet.v3.phi.V
                            );
-    std::cout << "Jet (pT, eta, phi) = (" << edmTaggedJet.pt() << ", " << edmTaggedJet.eta() << ", " << edmTaggedJet.phi() << ")" << std::endl;
     edmTaggedJet.setEncodedJet(l1t::PFJet::HWEncoding::CT, ctHWTaggedJet.pack());
     edmTaggedJet.setEncodedJet(l1t::PFJet::HWEncoding::GT, gtHWTaggedJet.pack());
     taggedJets.push_back(edmTaggedJet);

--- a/L1Trigger/Phase2L1ParticleFlow/python/L1MultiJetProducer_cff.py
+++ b/L1Trigger/Phase2L1ParticleFlow/python/L1MultiJetProducer_cff.py
@@ -8,7 +8,9 @@ l1tMultiJetProducerPuppi = L1MultiJetProducer.clone(
     maxJets = 16,
     minPt = 10,
     vtx = ("l1tVertexFinderEmulator","L1VerticesEmulation"),
-    MultiJetPath = cms.string(os.environ['CMSSW_BASE']+"/src/hls4ml-jettagger/MultiJetBaseline")
+    MultiJetPath = cms.string(os.environ['CMSSW_BASE']+"/src/hls4ml-jettagger/MultiJetBaseline"),
+    # TODO correct the classes
+    classes = cms.vstring(["uds", "g", "b", "c", "tau_p", "tau_n", "e", "mu"])
 )
 
 


### PR DESCRIPTION
This PR defines the data format and output product of the jet tagger. It's designed with some flexibility, such that the number of classes and their categories can be redefined in configuration (even if it's fixed for a specific model). The output product is a `l1t::PFJet` now with the `l1ct::Jet` and `l1gt::Jet` additionally populated with the jet tag scores. I've marked it draft with a few key things needing attention:
- it crashes with a segmentation fault (more below)
- feedback on the implementation and choices

I haven't been able to track down the segmentation fault. The module/code line where it occurs changes with each run, and it disappears when using `valgrind`. The only consistent behaviour I could reproduce is that removing the call to `std::vector<float> JetScore_float = fJetId_->computeFixed(srcjet, fUseRawPt_);`, the fault doesn't appear. 