### PR TITLE
Add a LUT for `sqrt(dxy)`

### DIFF
--- a/L1Trigger/Phase2L1ParticleFlow/interface/l1-converters/tkinput_ref.h
+++ b/L1Trigger/Phase2L1ParticleFlow/interface/l1-converters/tkinput_ref.h
@@ -172,6 +172,7 @@ namespace l1ct {
     const std::vector<int> &dPhiHGCalTanlLUT() const { return dPhiHGCalTanlLUT_; }
     const std::vector<int> &tanlLUT() const { return tanlLUT_; }
     const std::vector<l1ct::pt_t> &ptLUT() const { return ptLUT_; }
+    const std::vector<int> &dxyLUT() const { return dxyLUT_; }
 
     unsigned int countSetBits(unsigned int n) const {
       unsigned int count = 0;
@@ -253,6 +254,10 @@ namespace l1ct {
     // Rinv to pR LUT parameters
     int ptLUTShift_;
     std::vector<l1ct::pt_t> ptLUT_;
+
+    // dxy to sqrt(dxy) LUT parameters
+    int dxyLUTShift_;
+    std::vector<int> dxyLUT_;
 
     /// enable debug printout in some metods
     bool debug_;

--- a/L1Trigger/Phase2L1ParticleFlow/src/l1-converters/tkinput_ref.cpp
+++ b/L1Trigger/Phase2L1ParticleFlow/src/l1-converters/tkinput_ref.cpp
@@ -91,7 +91,7 @@ edm::ParameterSetDescription l1ct::TrackInputEmulator::getParameterSetDescriptio
   description.add<bool>("etaSigned", true);
   description.add<uint32_t>("phiBits", 10u);
   description.add<uint32_t>("z0Bits", 12u);
-  description.add<uint32_t>("dxyLUTBits", 10u);
+  description.add<uint32_t>("dxyLUTBits", 11u);
   description.ifValue(edm::ParameterDescription<std::string>("trackWordEncoding", "biased", true),
                       edm::allowedValues<std::string>("biased", "unbised", "stepping"));
   description.add<bool>("bitwiseAccurate", true);
@@ -434,8 +434,11 @@ void l1ct::TrackInputEmulator::configDxy(int lutBits) {
   dxyLUTShift_ = 12 - lutBits;
   dxyLUT_.resize(1 << lutBits);
   for (unsigned int u = 0, n = dxyLUT_.size(); u < n; ++u) {
-    float dxy = u * (1 << dxyLUTShift_) * l1ct::Scales::DXY_LSB;
-    float sqrtDxy = std::sqrt(dxy);
+    float dxy_l = u * (1 << dxyLUTShift_) * l1ct::Scales::DXY_LSB;
+    float dxy_h = (u+1) * (1 << dxyLUTShift_) * l1ct::Scales::DXY_LSB;
+    float sqrtDxy_l = std::sqrt(dxy_l);
+    float sqrtDxy_h = std::sqrt(dxy_h);
+    float sqrtDxy = (sqrtDxy_l + sqrtDxy_h) / 2;
     dxyLUT_[u] = l1ct::Scales::makeDxy(sqrtDxy);
   }
   if (debug_)

--- a/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
+++ b/L1Trigger/Phase2L1ParticleFlow/test/make_l1ct_binaryFiles_cfg.py
@@ -205,6 +205,8 @@ process.runPF = cms.Path(
         process.l1tLayer1HGCalNoTK +
         process.l1tLayer1HF +
         process.l1tLayer1 +
+        process.l1tLayer1BarrelExtended +
+        process.l1tLayer1HGCalExtended +
         process.l1tLayer2Deregionizer +
         process.l1tSC4PFL1PuppiCorrectedEmulator +
         process.l1tSC4NGJetProducer +
@@ -235,6 +237,9 @@ if not args.dumpFilesOFF:
     for det in "Barrel", "BarrelTDR", "BarrelSerenity", "HGCal", "HGCalElliptic", "HGCalNoTK", "HF":
         l1pf = getattr(process, 'l1tLayer1'+det)
         l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+".dump")
+    for det in "Barrel", "HGCal":
+        l1pf = getattr(process, 'l1tLayer1'+det+'Extended')
+        l1pf.dumpFileName = cms.untracked.string("TTbar_PU200_"+det+"Extended.dump")
 
 
 if args.tm18:


### PR DESCRIPTION
This PR implements a LUT for `sqrt(dxy)` in the track conversion. An equivalent firmware has been written for it in correlator-common, and I'll open a branch there as well. The extended tracking layer 1 configs are added to the binary file producer such that dump files are produced with extended tracking for use in the CI tests in correlator-common.